### PR TITLE
Remove calendly branding from schedule chat widget

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,7 +22,6 @@
                     text: "Schedule a Chat",
                     color: "#1a1a1a",
                     textColor: "#ffffff",
-                    branding: true,
                 });
             };
         </script>


### PR DESCRIPTION
The schedule chat widget looks like this now
<img width="242" alt="image" src="https://github.com/user-attachments/assets/b14710a2-636a-4f3d-8f7e-aa224724ca43" />
